### PR TITLE
Fix purchase links when items can't be added to a temp cart

### DIFF
--- a/core/amazon/index.js
+++ b/core/amazon/index.js
@@ -50,7 +50,7 @@ var amazonProduct = {
                     // *** ERROR *** no ASIN
                     console.log(`Item #${itemIdx} has no ASIN: `, JSON.stringify(curItem, null, 2));
                     curItem.cartCreated = false;
-                    curItem.cartUrl = "https://amazon.com";
+                    curItem.purchaseUrl = "https://amazon.com";
                 }
             }
             return Promise.all(promiseArray).then(() => {

--- a/core/amazon/index.js
+++ b/core/amazon/index.js
@@ -36,15 +36,20 @@ var amazonProduct = {
                     //Build virtual cart here
                     promiseArray.push(amazonProduct.createCart(curItem.ASIN, 1)
                         .then((url) => {
-
-                            if (url === undefined) {
-                                url = curItem.DetailPageURL[0];
+                            
+                            if (url !== undefined) {
+                                curItem.cartCreated = true;
+                                curItem.purchaseUrl = url;
+                            } else {
+                                curItem.cartCreated = false;
+                                curItem.purchaseUrl = curItem.DetailPageURL[0];
                             }
-                            curItem.cartUrl = url;
+                            
                         }));
                 } else {
                     // *** ERROR *** no ASIN
                     console.log(`Item #${itemIdx} has no ASIN: `, JSON.stringify(curItem, null, 2));
+                    curItem.cartCreated = false;
                     curItem.cartUrl = "https://amazon.com";
                 }
             }
@@ -75,7 +80,7 @@ var amazonProduct = {
         }, function (err) {
             // *** ERROR *** something bad happend when creating a temp cart... handle this better
             console.log(`ERROR creating cart for ${ASIN}`);
-            return 'https://amazon.com';
+            return undefined;
         });
     },
 

--- a/core/conversation-manager/index.js
+++ b/core/conversation-manager/index.js
@@ -104,8 +104,9 @@ const actions = {
                     console.log(`SEND LIST OF ITEMS`);
                     const items = request.context.items;
                     items.forEach((item)=> {
-
-                        item.cartUrl = `${config.CART_REDIRECT_URL}?user_id=${recipientId}&cart_url=${encodeURIComponent(item.cartUrl)}&ASIN=${item.ASIN}`;
+                        if (item.cartCreated) {
+                            item.purchaseUrl = `${config.CART_REDIRECT_URL}?user_id=${recipientId}&cart_url=${encodeURIComponent(item.purchaseUrl)}&ASIN=${item.ASIN}`;
+                        }
                     });
                     return messageSender.sendSearchResults(recipientId, items)
                         .then(() => {

--- a/core/conversation-manager/index.js
+++ b/core/conversation-manager/index.js
@@ -261,15 +261,21 @@ module.exports.handler = (message, sender, msgSender) => {
                             console.log(`Specific product after variation selection: ${JSON.stringify(product)}`);
                             return amazon.createCart(product.ASIN, 1)
                                 .then((cartUrl) => {
-                                    let modifiedUrl = `${config.CART_REDIRECT_URL}?user_id=${uid}&cart_url=${encodeURIComponent(cartUrl)}&ASIN=${product.ASIN}`;
-                                    console.log('URL WE WANT ' + modifiedUrl);
-                                    product.cartUrl = modifiedUrl;
+                                    if (cartUrl !== undefined) {
+                                        // Send variations summary with cart redirect url
+                                        let modifiedUrl = `${config.CART_REDIRECT_URL}?user_id=${uid}&cart_url=${encodeURIComponent(cartUrl)}&ASIN=${product.ASIN}`;
+                                        console.log('URL WE WANT ' + modifiedUrl);
+                                        product.cartUrl = modifiedUrl;
 
-                                    product.parentASIN = context.parentASIN;
-                                    return messageSender.sendVariationSummary(uid, product)
-                                        .catch((error) => {
-                                            console.log(`ERROR sending product summary: ${error}`);
-                                        });
+                                        product.parentASIN = context.parentASIN;
+                                        return messageSender.sendVariationSummary(uid, product)
+                                            .catch((error) => {
+                                                console.log(`ERROR sending product summary: ${error}`);
+                                            });
+                                    } else {
+                                        // Send message saying the user should try purchasing it on Amazon including link to parent
+                                        return messageSender.sendTextMessage(uid, "Sorry, I couldn't make a purchase link for that item... If you still want to buy it try using Amazon's website");
+                                    }
                                 }, (error) => {
                                     console.log(`ERROR creating cart after variation selection: ${error}`);
                                 });

--- a/core/facebook-message-sender/index.js
+++ b/core/facebook-message-sender/index.js
@@ -62,7 +62,7 @@ var facebookMessageSender = {
             else {
                 element.buttons = [{
                     type: "web_url",
-                    url: product.cartUrl,
+                    url: product.purchaseUrl,
                     title: "Purchase",
                     webview_height_ratio: "TALL"
                 }];

--- a/core/facebook-message-sender/index.js
+++ b/core/facebook-message-sender/index.js
@@ -192,7 +192,7 @@ var facebookMessageSender = {
      *
      * @param recipientId
      * @param product the single result that we are sending. { parentTitle, imageUrl (LARGE), variationNames,
-     * variationValues, cartUrl, price }
+     * variationValues, purchaseUrl, price }
      */
     sendVariationSummary: function (recipientId, product) {
         console.log(`Product to summarize: ${JSON.stringify(product)}`);
@@ -209,7 +209,7 @@ var facebookMessageSender = {
 
         element.buttons = [{
             type: "web_url",
-            url: product.cartUrl,
+            url: product.purchaseUrl,
             title: "Purchase",
             webview_height_ratio: "TALL"
         }, {

--- a/functions/cart-redirect.js
+++ b/functions/cart-redirect.js
@@ -3,36 +3,40 @@ var purchasedItemDAO = require('database').purchasedItemDAO;
 var config = require('./../config');
 
 /**
- * Lambda function for cart redirect that logs some information about the purchase click
- * uid, cart_url, and ASIN all need to be passed in as queries on the url
+ * Lambda function for purchase redirect that logs some information about the purchase click
+ * uid, redirect_url, ASIN, and is_cart all need to be passed in as queries on the url
  * @param event
  * @param context
  * @param callback
  */
 module.exports.cartRedirect = function (event, context, callback) {
-    console.log(`CART REDIRECT EVENT ${JSON.stringify(event, null, 2)}`);
-    console.log(`CART REDIRECT CONTEXT ${JSON.stringify(context, null, 2)}`);
+    console.log(`PURCHASE REDIRECT EVENT ${JSON.stringify(event, null, 2)}`);
+    console.log(`PURCHASE REDIRECT CONTEXT ${JSON.stringify(context, null, 2)}`);
     let querystring = event.params.querystring;
-    //Seems like the cart url somehow generates another request to this url...? This is a fix tho
+    //Seems like the purchase url somehow generates another request to this url...? This is a fix tho
     if (querystring['associate-id']) {
         console.log(`Skipping this request`);
         return;
     }
-    console.log(`CART REDIRECT EVENT ${JSON.stringify(event, null, 2)}`);
-    console.log(`CART REDIRECT CONTEXT ${JSON.stringify(context, null, 2)}`);
+    console.log(`PURCHASE REDIRECT EVENT ${JSON.stringify(event, null, 2)}`);
+    console.log(`PURCHASE REDIRECT CONTEXT ${JSON.stringify(context, null, 2)}`);
 
     let uid = querystring.user_id;
-    let cartParams = querystring.cart_url.substring(querystring.cart_url.indexOf("?") + 1);
+    let redirectUrl = querystring.redirect_url;
     let ASIN = querystring.ASIN;
+    let isCartUrl = querystring.is_cart;
     let isMobileRequest = event.params.header['CloudFront-Is-Mobile-Viewer'];
-    let cartUrl;
-    if (isMobileRequest)
-        cartUrl = `https://www.amazon.com/gp/aw/rcart?${cartParams}`;
-    else {
-        cartUrl = `https://www.amazon.com/gp/cart/aws-merge.html?${cartParams}`;
+    
+    if (isCartUrl === '1') {
+        let cartParams = redirectUrl.substring(redirectUrl.indexOf("?") + 1);
+        if (isMobileRequest)
+            redirectUrl = `https://www.amazon.com/gp/aw/rcart?${cartParams}`;
+        else {
+            redirectUrl = `https://www.amazon.com/gp/cart/aws-merge.html?${cartParams}`;
+        }
     }
     purchasedItemDAO.addItem(uid, ASIN).then(()=> {
-        console.log(`CART REDIRECTED - ${cartUrl}`);
-        context.succeed({location: cartUrl});
+        console.log(`PURCHASE REDIRECTED - ${redirectUrl}`);
+        context.succeed({location: redirectUrl});
     });
 }; 


### PR DESCRIPTION
When items can't be added to a cart for whatever reason we should

a. Have the purchase link in search results just go to the item's page on Amazon
b. Not send a variation summary if trying to purchase item after selecting variations. Instead notify user and provide a link to the parent's page on Amazon

The editing of cart redirect url was always expecting a valid cart url which was not true for items in this category. Made sure the response from create cart was being used appropriately.

The message sent if we can't create a cart after variation selection currently doesn't have a link to the parent's page... should we add it later?
