### PR TITLE
Fix issue with No Problem getting sent a lot

### DIFF
--- a/core/conversation-manager/index.js
+++ b/core/conversation-manager/index.js
@@ -11,11 +11,6 @@ let sessionsDAO = require('database').sessionsDAO;
 
 const config = require('./../../config');
 const WIT_TOKEN = config.WIT_TOKEN;
-const TABLE_PREFIX = config.TABLE_PREFIX;
-
-// for dynamodb configuration
-let aws = require('aws-sdk');
-aws.config.update({region: 'us-east-1'});
 
 // Store messageSender in a variable accessible by the Wit actions
 let messageSender;

--- a/core/conversation-manager/index.js
+++ b/core/conversation-manager/index.js
@@ -201,7 +201,8 @@ module.exports.handler = (message, sender, msgSender) => {
                             // handle misunderstood messages
                             delete ctx.notUnderstood;
                             messageSender.sendTypingMessage(uid);
-                            return messageSender.sendTextMessage(uid, "I'm sorry, I don't understand what you're trying to say.")
+                            console.log(`SEND I don't understand message`);
+                            return messageSender.sendTextMessage(uid, "I'm sorry, I don't understand that")
                                 .then(sessionsDAO.updateContext(uid, ctx));
                         } else {
                             return sessionsDAO.updateContext(uid, ctx);

--- a/core/node-wit/lib/wit.js
+++ b/core/node-wit/lib/wit.js
@@ -114,10 +114,12 @@ function Wit(opts) {
       // For 'I don't understand' message
       if (request.entities !== undefined) {
         let confidence = 0;
-        for (var entity in request.entities) {
-          confidence += request.entities[entity][0]['confidence'];
+        if (Object.keys(request.entities).length > 0) {
+          for (var entity in request.entities) {
+            confidence += request.entities[entity][0]['confidence'];
+          }
+          confidence = confidence / Object.keys(request.entities).length;
         }
-        confidence = confidence / Object.keys(request.entities).length;
 
         if (confidence < 0.8) {
           console.log(`AVERAGE CONFIDENCE ${confidence} is below threshold`);

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "facebook-event-converter": "file:./core/facebook-event-converter",
     "facebook-message-sender": "file:./core/facebook-message-sender",
     "conversation-manager": "file:./core/conversation-manager",
-    "amazon": "file:./core/amazon",
-    "node-wit": "file:./core/node-wit"
+    "amazon": "file:./core/amazon"
   },
   "devDependencies": {
     "aws-sdk": "^2.6.11",


### PR DESCRIPTION
"No problem" was being sent instead of "I don't understand" when there were no entities parsed by Wit because the average confidence was getting set to NaN because 0/0 = Nan.

NaN < 0.8 evaluates to false so the I don't understand message was getting skipped, allowing No problem to get sent as the closest match to an empty entity object. Just added a check so that when there are no entities the confidence is 0 instead of NaN.
