### PR TITLE
Implement threshold for variation selection through conversation

### DIFF
--- a/core/amazon/index.js
+++ b/core/amazon/index.js
@@ -82,6 +82,7 @@ var amazonProduct = {
                 var variationKeys = json.variationKeys;
                 var parentTitle = json.parentTitle;
                 var map = json.map;
+                var conversational = json.conversational;
                 //console.log("resolve variationKeys:", JSON.stringify(variationKeys, null, 2));
                 //console.log("resolve map:", JSON.stringify(map, null, 2));
                 for (var i = 0; i < variationValues.length; i++) {
@@ -103,7 +104,8 @@ var amazonProduct = {
                         ASIN: ASIN,
                         variationKey: variationKeys[variationValues.length],
                         variationOptions: variationValues.length + 1 == variationKeys.length ? map : Object.keys(map),
-                        lastVariation: variationValues.length + 1 == variationKeys.length ? true : false
+                        lastVariation: variationValues.length + 1 == variationKeys.length ? true : false,
+                        conversational: conversational
                     });
                 }
             }, function (err) {
@@ -125,6 +127,7 @@ var amazonProduct = {
                 result[0].Variations[0].VariationDimensions[0].VariationDimension != undefined &&
                 result[0].Variations[0].VariationDimensions[0].VariationDimension.length > 0) {
 
+                var conversational = true;
                 var map = {};
                 var variationKeys = result[0].Variations[0].VariationDimensions[0].VariationDimension;
                 var parentTitle = result[0].ItemAttributes && result[0].ItemAttributes[0]
@@ -150,7 +153,13 @@ var amazonProduct = {
                                 var variation = variationKeys[variationIdx];
                                 var value = itemAttributes[variation];
                                 if (!(value in ref)) {
+                                    // Otherwise, add value to map
                                     if (variationIdx == variationKeys.length - 1) {
+                                        // Check if the last level variations are too numerous for selection through conversation
+                                        if (Object.keys(ref).length == 10) {
+                                            conversational = false;
+                                        }
+
                                         ref[value] = {
                                             "ASIN": item.ASIN && item.ASIN[0],
                                             "image": item.LargeImage && item.LargeImage[0] && item.LargeImage[0].URL && item.LargeImage[0].URL[0] || "no image",
@@ -165,6 +174,11 @@ var amazonProduct = {
                                             && item.ItemAttributes[0].Title && item.ItemAttributes[0].Title[0]
                                         }
                                     } else {
+                                        // Check if variation values are too long or too numerous for selection through conversation
+                                        if (value.length > 20 || Object.keys(ref).length == 9) {
+                                            conversational = false;
+                                        }
+
                                         ref[value] = {};
                                         ref = ref[value];
                                     }
@@ -179,6 +193,7 @@ var amazonProduct = {
 
 
                     return {
+                        conversational: conversational,
                         variationKeys: variationKeys,
                         map: map,
                         parentTitle: parentTitle

--- a/core/amazon/index.js
+++ b/core/amazon/index.js
@@ -155,11 +155,6 @@ var amazonProduct = {
                                 if (!(value in ref)) {
                                     // Otherwise, add value to map
                                     if (variationIdx == variationKeys.length - 1) {
-                                        // Check if the last level variations are too numerous for selection through conversation
-                                        if (Object.keys(ref).length == 10) {
-                                            conversational = false;
-                                        }
-
                                         ref[value] = {
                                             "ASIN": item.ASIN && item.ASIN[0],
                                             "image": item.LargeImage && item.LargeImage[0] && item.LargeImage[0].URL && item.LargeImage[0].URL[0] || "no image",
@@ -173,14 +168,19 @@ var amazonProduct = {
                                             "title": item.ItemAttributes && item.ItemAttributes[0]
                                             && item.ItemAttributes[0].Title && item.ItemAttributes[0].Title[0]
                                         }
-                                    } else {
-                                        // Check if variation values are too long or too numerous for selection through conversation
-                                        if (value.length > 20 || Object.keys(ref).length == 9) {
+
+                                        // Check if the last level variations are too numerous for selection through conversation
+                                        if (Object.keys(ref).length > 10) {
                                             conversational = false;
                                         }
-
+                                    } else {
                                         ref[value] = {};
                                         ref = ref[value];
+
+                                        // Check if variation values are too long or too numerous for selection through conversation
+                                        if (value.length > 20 || Object.keys(ref).length > 9) {
+                                            conversational = false;
+                                        }
                                     }
                                 } else {
                                     ref = ref[value];

--- a/core/conversation-manager/index.js
+++ b/core/conversation-manager/index.js
@@ -147,10 +147,21 @@ const actions = {
 
                     return amazon.variationPick(context.parentASIN, context.selectedVariations, null)
                         .then((result) => {
-                            return messageSender.sendVariationSelectionPrompt(recipientId, result)
-                                .catch((error) => {
-                                    console.log(`ERROR sending variation prompt: ${error}`);
-                                });
+                            if (result.conversational) {
+                                return messageSender.sendVariationSelectionPrompt(recipientId, result)
+                                    .catch((error) => {
+                                        console.log(`ERROR sending variation prompt: ${error}`);
+                                    });
+                            } else {
+                                // Send message to user explaining they should go to Amazon to select variations
+                                let itemLink = `http://asin.info/a/${context.parentASIN}`;
+                                delete context.parentASIN;
+                                delete context.selectedVariations;
+                                return messageSender.outsourceVariationSelection(recipientId, itemLink)
+                                    .catch((error) => {
+                                        console.log(`ERROR sending outsourcing message for variation selection: ${error}`);
+                                    })
+                            }
                         }, (error) => {
                             console.log(`ERROR sending variation prompt: ${error}`);
                         })

--- a/core/facebook-message-sender/index.js
+++ b/core/facebook-message-sender/index.js
@@ -102,6 +102,40 @@ var facebookMessageSender = {
     },
 
     /**
+     * Tell the user they should select item options on Amazon
+     * @param recipient_id
+     * @param item_link Link to the parent itme on Amazon
+     */
+    outsourceVariationSelection: function (recipient_id, item_link) {
+        console.log(`SEND offload variation prompt: ${item_link}`);
+
+        let offloadMsg = "The options for this item are too complex to select here...";
+
+        let buttons = [{
+            type: 'web_url',
+            url: item_link,
+            title: 'Go to Amazon',
+            webview_height_ratio: 'TALL'
+        }];
+
+        let json = {
+            recipient: {id: recipient_id},
+            message: {
+                attachment: {
+                    type: "template",
+                    payload: {
+                        template_type: "button",
+                        text: offloadMsg,
+                        buttons: buttons
+                    }
+                }
+            }
+        };
+
+        return callSendAPI(json);
+    },
+
+    /**
      *
      * @param recipient_id
      * @param variation_array [{ title:'sfsd', ASIN: asin }]


### PR DESCRIPTION
Right now, the variations are flagged NOT conversational only when they exceed the maximum allowable length or number as defined by FB messenger.

For all variations besides the last one, this means the variation values can not exceed 20 chars in length and the number of values can't exceed 9 since we can only have 10 quick replies and one must be for 'Nevermind'.

For the last variation, we can use all 10 slots in the slideshow and are not limited to 20 chars for the value name.

In the future we can always make these limits more strict but not less strict.
